### PR TITLE
Support multiple redis instances

### DIFF
--- a/lib/warlock.js
+++ b/lib/warlock.js
@@ -2,12 +2,10 @@ var crypto       = require('crypto');
 var Scripty      = require('node-redis-scripty');
 var UUID         = require('uuid');
 
-var scripty;
-
 module.exports = function(redis){
   var warlock = {};
 
-  scripty = new Scripty(redis);
+  var scripty = new Scripty(redis);
 
   warlock.makeKey = function(key) {
     return key + ':lock';


### PR DESCRIPTION
Currently if we call warlock using different redis instances, locks will be created in the respective instances, but only one instance will be used for unlocking (since the scripty instance is shared). This change allows multiple redis instances to be used.